### PR TITLE
Seed initial stock items from presets when storage empty

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import './style.css';
 
 import type { Item } from './storage/Storage';
 import { CATEGORIES } from './storage/Storage';
-import { loadAll, saveItem, removeItem } from './storage/db';
+import { loadAll, saveItem, removeItem, seedIfEmpty } from './storage/db';
 import { nowISO } from './utils/time';
 import { initPushIfNeeded } from './push/onesignal';
 
@@ -261,6 +261,7 @@ async function route() {
 
 async function main() {
   await initPushIfNeeded(); // OneSignal(v16) 初期化（ボタン操作時許可は各画面側で実装済み前提）
+  seedIfEmpty();
   window.addEventListener('hashchange', route);
   await route();
 }

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -1,13 +1,21 @@
 // src/storage/db.ts
 import type { Item } from './Storage';
+import { PRESETS } from '../presets';
 
 const LS_KEY = 'stocklite/items';
 
 const read = (): Item[] => {
-  try { return JSON.parse(localStorage.getItem(LS_KEY) || '[]'); }
-  catch { return []; }
+  try {
+    return JSON.parse(localStorage.getItem(LS_KEY) || '[]');
+  } catch {
+    return [];
+  }
 };
 const write = (items: Item[]) => localStorage.setItem(LS_KEY, JSON.stringify(items));
+
+export const seedIfEmpty = () => {
+  if (read().length === 0) write(PRESETS);
+};
 
 export const loadAll = (): Item[] => read();
 


### PR DESCRIPTION
## Summary
- auto-populate localStorage with preset stock items on first run
- decouple preset seeding from `loadAll` via new `seedIfEmpty`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c56a6670d48327a9cc655ac9d929bf