### PR TITLE
Seed initial items, disable Safari zoom, and refine edit form layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
     <title>StockLite</title>
 
     <!-- スタイル（style.css のみ） -->

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import './style.css';
 
 import type { Item } from './storage/Storage';
 import { CATEGORIES } from './storage/Storage';
-import { loadAll, saveItem, removeItem } from './storage/db';
+import { loadAll, saveItem, removeItem, seedIfEmpty } from './storage/db';
 import { nowISO } from './utils/time';
 import { initPushIfNeeded } from './push/onesignal';
 
@@ -138,8 +138,19 @@ function categorySelect(value: Item['category']) {
   for (const c of CATEGORIES) sel.append(el('option', { value: c, textContent: c, selected: c === value }));
   return sel;
 }
-function fieldWrap(label: string, child: HTMLElement, cls: string) {
-  return el('div', { className: `field ${cls}` }, el('div', { className: 'field-label', textContent: label }), child);
+function fieldWrap(
+  label: string,
+  child: HTMLElement,
+  cls: string,
+  note?: string,
+) {
+  return el(
+    'div',
+    { className: `field ${cls}` },
+    el('div', { className: 'field-label', textContent: label }),
+    child,
+    note ? el('div', { className: 'field-note', textContent: note }) : null,
+  );
 }
 
 function renderEditRow(it: Item) {
@@ -155,7 +166,7 @@ function renderEditRow(it: Item) {
     fieldWrap('名前', nameI, 'ed-name'),
     fieldWrap('カテゴリ', catS, 'ed-cat'),
     fieldWrap('個数', qtyI, 'ed-qty'),
-    fieldWrap('閾値（この数以下で要補充）', thI, 'ed-th'),
+    fieldWrap('閾値', thI, 'ed-th', 'この数以下で要補充'),
     el('div', { className: 'save' }, btnSave),
     el('div', { className: 'del'  }, btnDel),
   );
@@ -194,7 +205,7 @@ function renderAddRow() {
     fieldWrap('（新規）名前', nameI, 'ed-name'),
     fieldWrap('カテゴリ',     catS,  'ed-cat'),
     fieldWrap('個数',         qtyI,  'ed-qty'),
-    fieldWrap('閾値（この数以下で要補充）', thI, 'ed-th'),
+    fieldWrap('閾値',         thI,  'ed-th', 'この数以下で要補充'),
     el('div', { className: 'save' }, btnAdd),
     el('div', { className: 'del'  }, btnClear),
   );
@@ -236,17 +247,25 @@ function renderAddRow() {
 async function renderEdit() {
   const root = $('#app')!;
   root.textContent = '';
+  const items = (await Promise.resolve(loadAll()))
+    .filter(i => !i.deleted)
+    .sort((a, b) =>
+      a.category === b.category
+        ? jaSortByName(a, b)
+        : CATEGORIES.indexOf(a.category) - CATEGORIES.indexOf(b.category),
+    );
 
   root.append(
     renderEditHeader(),
     el('div', { className: 'edit-panel' },
+      el('h3', { className: 'section-title', textContent: '新規追加' }),
       renderAddRow(),
-      el('div', { className: 'edit-list' },
-        ...(await Promise.resolve(loadAll()))
-          .filter(i => !i.deleted)
-          .sort((a, b) => (a.category === b.category ? jaSortByName(a, b) : CATEGORIES.indexOf(a.category) - CATEGORIES.indexOf(b.category)))
-          .map(renderEditRow)
-      )
+      items.length
+        ? el('h3', { className: 'section-title', textContent: '既存アイテム' })
+        : null,
+      items.length
+        ? el('div', { className: 'edit-list' }, ...items.map(renderEditRow))
+        : null,
     ),
   );
 
@@ -261,6 +280,7 @@ async function route() {
 
 async function main() {
   await initPushIfNeeded(); // OneSignal(v16) 初期化（ボタン操作時許可は各画面側で実装済み前提）
+  seedIfEmpty();
   window.addEventListener('hashchange', route);
   await route();
 }

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -1,13 +1,21 @@
 // src/storage/db.ts
 import type { Item } from './Storage';
+import { PRESETS } from '../presets';
 
 const LS_KEY = 'stocklite/items';
 
 const read = (): Item[] => {
-  try { return JSON.parse(localStorage.getItem(LS_KEY) || '[]'); }
-  catch { return []; }
+  try {
+    return JSON.parse(localStorage.getItem(LS_KEY) || '[]');
+  } catch {
+    return [];
+  }
 };
 const write = (items: Item[]) => localStorage.setItem(LS_KEY, JSON.stringify(items));
+
+export const seedIfEmpty = () => {
+  if (read().length === 0) write(PRESETS);
+};
 
 export const loadAll = (): Item[] => read();
 

--- a/src/style.css
+++ b/src/style.css
@@ -52,6 +52,7 @@ h2.cat { margin: 18px 12px 8px; font-size: 20px; letter-spacing: .02em; }
 /* ---- button ---- */
 .btn {
   -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
   display:inline-flex; align-items:center; justify-content:center;
   gap:6px;
   border:1px solid var(--border); background:#fff; color:#222;
@@ -105,7 +106,7 @@ h2.cat { margin: 18px 12px 8px; font-size: 20px; letter-spacing: .02em; }
     "cat  cat"
     "qty  th"
     "save del";
-  grid-template-columns: 1fr 140px;
+  grid-template-columns: 1fr 1fr;
 }
 
 /* 広い画面では横一列 */
@@ -124,6 +125,11 @@ h2.cat { margin: 18px 12px 8px; font-size: 20px; letter-spacing: .02em; }
 .field-label{
   font-size:12px; color:var(--muted);
   margin: 2px 2px 6px;
+}
+.field-note{
+  font-size:11px;
+  color:var(--muted);
+  margin:4px 2px 0;
 }
 
 /* エリア割当（ラッパーにクラスを付与） */
@@ -158,6 +164,14 @@ h2.cat { margin: 18px 12px 8px; font-size: 20px; letter-spacing: .02em; }
     "cat  cat"
     "qty  th"
     "add  clear";
+  background:#f9fbff;
+  border-style:dashed;
+}
+
+.section-title{
+  margin: 8px 4px;
+  font-size: 14px;
+  color: var(--muted);
 }
 
 /* 見た目微調整 */


### PR DESCRIPTION
## Summary
- auto-populate localStorage with preset stock items on first run
- disable double-tap zoom on iOS Safari buttons
- decouple preset seeding from `loadAll` via new `seedIfEmpty`
- balance quantity and threshold inputs and add helper note
- highlight new item form with section headers and dashed styling

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c56a6670d48327a9cc655ac9d929bf