### PR TITLE
Enable dynamic categories and fix form alignment

### DIFF
--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -1,6 +1,31 @@
 // src/storage/Storage.ts
-export const CATEGORIES = ['キッチン', '洗面・トイレ'] as const;
-export type Category = (typeof CATEGORIES)[number];
+const CAT_KEY = 'stocklite/categories';
+const DEFAULT_CATEGORIES = ['キッチン', '洗面・トイレ'];
+
+const loadCategories = (): string[] => {
+  if (typeof localStorage === 'undefined') return [...DEFAULT_CATEGORIES];
+  try {
+    const stored = JSON.parse(localStorage.getItem(CAT_KEY) || '[]');
+    if (Array.isArray(stored) && stored.length) return stored as string[];
+  } catch {
+    /* ignore */
+  }
+  localStorage.setItem(CAT_KEY, JSON.stringify(DEFAULT_CATEGORIES));
+  return [...DEFAULT_CATEGORIES];
+};
+
+export let CATEGORIES: string[] = loadCategories();
+
+export const addCategory = (c: string) => {
+  const name = c.trim();
+  if (!name || CATEGORIES.includes(name)) return;
+  CATEGORIES.push(name);
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(CAT_KEY, JSON.stringify(CATEGORIES));
+  }
+};
+
+export type Category = string;
 
 export type Item = {
   id: string;

--- a/src/style.css
+++ b/src/style.css
@@ -121,7 +121,7 @@ h2.cat { margin: 18px 12px 8px; font-size: 20px; letter-spacing: .02em; }
 }
 
 /* ▼ 追加：フィールド共通ラッパーとラベル */
-.field{ display:flex; flex-direction:column; }
+.field{ display:flex; flex-direction:column; width:100%; }
 .field-label{
   font-size:12px; color:var(--muted);
   margin: 2px 2px 6px;


### PR DESCRIPTION
## Summary
- Ensure edit form fields stretch to full width
- Allow adding new categories and persist them to localStorage

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c585c79bd88327949d99e50f1d411d