### PR TITLE
feat(history): track stock changes and export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "stock-lite",
       "version": "0.0.0",
       "dependencies": {
-        "chart.js": "^4.5.0",
         "idb": "^8.0.3",
         "uuid": "^11.1.0",
         "vite-plugin-pwa": "^1.0.2"
@@ -1943,12 +1942,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "license": "MIT"
-    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "15.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
@@ -2570,18 +2563,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/chart.js": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
-      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
-      }
     },
     "node_modules/commander": {
       "version": "2.20.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "vite-plugin-pwa": "^1.0.2"
       },
       "devDependencies": {
+        "jsdom": "^27.0.0",
         "ts-node": "^10.9.1",
         "typescript": "~5.8.3",
         "vite": "^7.1.0"
@@ -47,6 +48,50 @@
       "peerDependencies": {
         "ajv": ">=8"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.4.tgz",
+      "integrity": "sha512-cKjSKvWGmAziQWbCouOsFwb14mp1betm8Y7Fn+yglDMUUu3r9DCbJ9iJbeFDenLMqFbIMC0pQP8K+B8LAxX3OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.1.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
+      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.5.4.tgz",
+      "integrity": "sha512-RNSNk1dnB8lAn+xdjlRoM4CzdVrHlmXZtSXAWs2jyl4PiBRWqTZr9ML5M710qgd9RPTBsVG6P0SLy7dwy0Foig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -1506,6 +1551,144 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+      "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
@@ -2389,6 +2572,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -2532,6 +2725,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -2704,6 +2907,86 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.0.tgz",
+      "integrity": "sha512-RveJPnk3m7aarYQ2bJ6iw+Urh55S6FzUiqtBq+TihnTDP4cI8y/TYDqGOyqgnG1J1a6BxJXZsV9JFSTulm9Z7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.0.3",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+        "css-tree": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.0.0.tgz",
+      "integrity": "sha512-+0q+Pc6oUhtbbeUfuZd4heMNOLDJDdagYxv756mCf9vnLF+NTj4zvv5UyYNkHJpc3CJIesMVoEIOdhi7L9RObA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.1",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -2771,6 +3054,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -2859,6 +3149,19 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.199.tgz",
       "integrity": "sha512-3gl0S7zQd88kCAZRO/DnxtBKuhMO4h0EaQIN3YgZfV6+pW+5+bf2AdQeHNESCoaQqo/gjGVYEf2YM4O5HJQqpQ==",
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -3417,6 +3720,60 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/idb": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
@@ -3669,6 +4026,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -3855,6 +4219,83 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/jsdom": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.5.4",
+        "cssstyle": "^5.3.0",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.3.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0",
+        "ws": "^8.18.2",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.0.0.tgz",
+      "integrity": "sha512-+0q+Pc6oUhtbbeUfuZd4heMNOLDJDdagYxv756mCf9vnLF+NTj4zvv5UyYNkHJpc3CJIesMVoEIOdhi7L9RObA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.1",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -3973,6 +4414,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4080,6 +4528,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-is-absolute": {
@@ -4357,6 +4818,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -4427,6 +4895,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -4750,6 +5238,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -4809,6 +5304,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.14.tgz",
+      "integrity": "sha512-lMNHE4aSI3LlkMUMicTmAG3tkkitjOQGDTFboPJwAg2kJXKP1ryWEyqujktg5qhrFZOkk5YFzgkxg3jErE+i5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.14"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.14.tgz",
+      "integrity": "sha512-viZGNK6+NdluOJWwTO9olaugx0bkKhscIdriQQ+lNNhwitIKvb+SvhbYgnCz6j9p7dX3cJntt4agQAKMXLjJ5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -5215,11 +5743,47 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "7.1.0",
@@ -5629,6 +6193,45 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "vite-plugin-pwa": "^1.0.2"
       },
       "devDependencies": {
+        "ts-node": "^10.9.1",
         "typescript": "~5.8.3",
         "vite": "^7.1.0"
       }
@@ -1481,6 +1482,30 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.8",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
@@ -2282,11 +2307,50 @@
         "string.prototype.matchall": "^4.0.6"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.4.0.tgz",
+      "integrity": "sha512-gUuVEAK4/u6F9wRLznPUU4WGUacSEBDPoC2TrBkw3GAnOLHBL45QdfHOXp1kJ4ypBGLxTOB+t7NJLpKoC3gznQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.11.0"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -2312,6 +2376,19 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -2327,6 +2404,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -2604,6 +2688,13 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -2722,6 +2813,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -3856,6 +3957,13 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4712,6 +4820,50 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
@@ -4830,6 +4982,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.11.0.tgz",
+      "integrity": "sha512-kt1ZriHTi7MU+Z/r9DOdAI3ONdaR3M3csEaRc6ewa4f4dTvX4cQCbJ4NkEn0ohE4hHtq85+PhPSTY+pO/1PwgA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
@@ -4943,6 +5103,13 @@
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.1.1",
@@ -5468,6 +5635,16 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "devDependencies": {
     "typescript": "~5.8.3",
     "vite": "^7.1.0"
   },
   "dependencies": {
-    "chart.js": "^4.5.0",
     "idb": "^8.0.3",
     "uuid": "^11.1.0",
     "vite-plugin-pwa": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "node --loader ts-node/esm --test"
+    "test": "NODE_ENV=test node --loader ts-node/esm --test"
   },
   "devDependencies": {
+    "jsdom": "^27.0.0",
+    "ts-node": "^10.9.1",
     "typescript": "~5.8.3",
-    "vite": "^7.1.0",
-    "ts-node": "^10.9.1"
+    "vite": "^7.1.0"
   },
   "dependencies": {
     "idb": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "node --test"
+    "test": "node --loader ts-node/esm --test"
   },
   "devDependencies": {
     "typescript": "~5.8.3",
-    "vite": "^7.1.0"
+    "vite": "^7.1.0",
+    "ts-node": "^10.9.1"
   },
   "dependencies": {
     "idb": "^8.0.3",

--- a/src/main.ts
+++ b/src/main.ts
@@ -456,7 +456,21 @@ async function renderHistory(id: string) {
     }
   }
 
-  if (!it) { root.textContent = 'アイテムが見つかりません'; return; }
+  if (!it) {
+    it = {
+      id,
+      name: '不明なアイテム',
+      category: '',
+      qty: 0,
+      threshold: 0,
+      lastRefillAt: '',
+      nextRefillAt: '',
+      createdAt: nowISO(),
+      updatedAt: nowISO(),
+      deleted: false,
+      version: 1,
+    };
+  }
 
   root.append(renderHistoryHeader(it.name));
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,11 @@ function renderListHeader() {
 }
 
 function renderCard(it: Item) {
+  if (!it.id) {
+    it.id = uuid();
+    it.updatedAt = nowISO();
+    saveItem(it);
+  }
   const need = it.qty <= it.threshold;
   const tag = need
     ? el('span', { className: 'tag danger', textContent: '要補充' })

--- a/src/main.ts
+++ b/src/main.ts
@@ -418,7 +418,18 @@ async function renderHistory(id: string) {
 
   const items = await Promise.resolve(loadAll());
   let it = items.find(x => x.id === id);
-  const allHist = historyForItem(id);
+  let allHist = historyForItem(id);
+
+  if (!it && !allHist.length) {
+    const blanks = historyForItem('');
+    const match = blanks.find(b => items.some(i => i.name === b.itemName));
+    if (match) {
+      it = items.find(i => i.name === match.itemName)!;
+      updateHistoryItemId('', it.id, it.name);
+      allHist = historyForItem(it.id);
+    }
+  }
+
   if (!it && allHist.length) {
     const last = allHist[allHist.length - 1];
     it = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,10 @@
    - 閲覧(#/) と 編集(#/edit) をシンプルに切替
    ========================= */
 
-if (typeof process === 'undefined' || process.env.NODE_ENV !== 'test') {
+// Node.js 環境で型定義がない場合でも `process` を参照できるよう宣言
+declare const process: { env?: Record<string, string | undefined> } | undefined;
+
+if (typeof process === 'undefined' || process?.env?.NODE_ENV !== 'test') {
   await import('./style.css');
 }
 
@@ -397,15 +400,21 @@ function renderHistoryHeader(name: string) {
 
 function drawLine(canvas: HTMLCanvasElement, data: number[], min: number, max: number) {
   const ctx = canvas.getContext('2d');
-  if (!ctx) return;
+  if (!ctx || data.length === 0) return;
   const w = canvas.width;
   const h = canvas.height;
   ctx.clearRect(0, 0, w, h);
+
+  // 値に変化がない場合は線が底に張り付いて見えなくなるため、上下に余白を作る
+  if (min === max) {
+    min -= 1;
+    max += 1;
+  }
   const range = max - min || 1;
-  const stepX = w / (data.length - 1);
+  const stepX = data.length > 1 ? w / (data.length - 1) : 0;
   ctx.beginPath();
   data.forEach((q, i) => {
-    const x = i * stepX;
+    const x = data.length > 1 ? i * stepX : w / 2;
     const y = h - ((q - min) / range) * h;
     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   });
@@ -560,7 +569,7 @@ async function main() {
   await route();
 }
 
-if (typeof process === 'undefined' || process.env.NODE_ENV !== 'test') {
+if (typeof process === 'undefined' || process?.env?.NODE_ENV !== 'test') {
   main();
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,14 +6,15 @@
    - 閲覧(#/) と 編集(#/edit) をシンプルに切替
    ========================= */
 
-import './style.css';
+if (typeof process === 'undefined' || process.env.NODE_ENV !== 'test') {
+  await import('./style.css');
+}
 
-import type { Item } from './storage/Storage';
-import { CATEGORIES, addCategory } from './storage/Storage';
-import { loadAll, saveItem, removeItem, seedIfEmpty } from './storage/db';
-import { nowISO } from './utils/time';
-import { initPushIfNeeded } from './push/onesignal';
-import { appendHistory, recentHistory, historyForItem, historySince, updateHistoryItemId } from './storage/history';
+import type { Item } from './storage/Storage.ts';
+import { CATEGORIES, addCategory } from './storage/Storage.ts';
+import { loadAll, saveItem, removeItem, seedIfEmpty } from './storage/db.ts';
+import { nowISO } from './utils/time.ts';
+import { appendHistory, recentHistory, historyForItem, historySince, updateHistoryItemId } from './storage/history.ts';
 
 // ---------- 小ユーティリティ ----------
 const $ = <T extends HTMLElement>(sel: string, root: ParentNode = document) =>
@@ -552,10 +553,15 @@ async function route() {
 }
 
 async function main() {
+  const { initPushIfNeeded } = await import('./push/onesignal.ts');
   await initPushIfNeeded(); // OneSignal(v16) 初期化（ボタン操作時許可は各画面側で実装済み前提）
   seedIfEmpty();
   window.addEventListener('hashchange', route);
   await route();
 }
 
-main();
+if (typeof process === 'undefined' || process.env.NODE_ENV !== 'test') {
+  main();
+}
+
+export { renderHistory };

--- a/src/main.ts
+++ b/src/main.ts
@@ -420,32 +420,42 @@ async function renderHistory(id: string) {
   let it = items.find(x => x.id === id);
   let allHist = historyForItem(id);
 
+  if (!it && allHist.length) {
+    const last = allHist[allHist.length - 1];
+    const named = items.find(i => i.name === last.itemName);
+    if (named) {
+      updateHistoryItemId(id, named.id, named.name);
+      id = named.id;
+      it = named;
+      allHist = historyForItem(id);
+    } else {
+      it = {
+        id,
+        name: last.itemName || '不明なアイテム',
+        category: '',
+        qty: last.qtyAfter,
+        threshold: 0,
+        lastRefillAt: '',
+        nextRefillAt: '',
+        createdAt: last.timestamp,
+        updatedAt: last.timestamp,
+        deleted: false,
+        version: 1,
+      };
+    }
+  }
+
   if (!it && !allHist.length) {
     const blanks = historyForItem('');
     const match = blanks.find(b => items.some(i => i.name === b.itemName));
     if (match) {
-      it = items.find(i => i.name === match.itemName)!;
-      updateHistoryItemId('', it.id, it.name);
-      allHist = historyForItem(it.id);
+      const target = items.find(i => i.name === match.itemName)!;
+      updateHistoryItemId('', target.id, target.name);
+      it = target;
+      allHist = historyForItem(target.id);
     }
   }
 
-  if (!it && allHist.length) {
-    const last = allHist[allHist.length - 1];
-    it = {
-      id,
-      name: last.itemName || '不明なアイテム',
-      category: '',
-      qty: last.qtyAfter,
-      threshold: 0,
-      lastRefillAt: '',
-      nextRefillAt: '',
-      createdAt: last.timestamp,
-      updatedAt: last.timestamp,
-      deleted: false,
-      version: 1,
-    };
-  }
   if (!it) { root.textContent = 'アイテムが見つかりません'; return; }
 
   root.append(renderHistoryHeader(it.name));

--- a/src/main.ts
+++ b/src/main.ts
@@ -404,17 +404,11 @@ function drawLine(canvas: HTMLCanvasElement, data: number[], min: number, max: n
   const w = canvas.width;
   const h = canvas.height;
   ctx.clearRect(0, 0, w, h);
-
-  // 値に変化がない場合は線が底に張り付いて見えなくなるため、上下に余白を作る
-  if (min === max) {
-    min -= 1;
-    max += 1;
-  }
   const range = max - min || 1;
-  const stepX = data.length > 1 ? w / (data.length - 1) : 0;
+  const stepX = w / (data.length - 1);
   ctx.beginPath();
   data.forEach((q, i) => {
-    const x = data.length > 1 ? i * stepX : w / 2;
+    const x = i * stepX;
     const y = h - ((q - min) / range) * h;
     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -422,7 +422,7 @@ async function renderHistory(id: string) {
 
   if (!it && allHist.length) {
     const last = allHist[allHist.length - 1];
-    const named = items.find(i => i.name === last.itemName);
+    const named = items.find(i => i.id === last.itemId || i.name === last.itemName);
     if (named) {
       updateHistoryItemId(id, named.id, named.name);
       id = named.id;

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import { CATEGORIES, addCategory } from './storage/Storage';
 import { loadAll, saveItem, removeItem, seedIfEmpty } from './storage/db';
 import { nowISO } from './utils/time';
 import { initPushIfNeeded } from './push/onesignal';
-import { appendHistory, recentHistory, historyForItem, historySince } from './storage/history';
+import { appendHistory, recentHistory, historyForItem, historySince, updateHistoryItemId } from './storage/history';
 
 // ---------- 小ユーティリティ ----------
 const $ = <T extends HTMLElement>(sel: string, root: ParentNode = document) =>
@@ -54,9 +54,11 @@ function renderListHeader() {
 
 function renderCard(it: Item) {
   if (!it.id) {
+    const oldId = it.id || '';
     it.id = uuid();
     it.updatedAt = nowISO();
     saveItem(it);
+    updateHistoryItemId(oldId, it.id, it.name);
   }
   const need = it.qty <= it.threshold;
   const tag = need

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -26,7 +26,7 @@ export const seedIfEmpty = () => {
 };
 
 const normalize = (it: any): Item => ({
-  id: typeof it?.id === 'string' ? it.id : uuid(),
+  id: typeof it?.id === 'string' && it.id ? it.id : uuid(),
   name: typeof it?.name === 'string' ? it.name : '',
   category: typeof it?.category === 'string' ? it.category : '',
   qty: typeof it?.qty === 'number' ? it.qty : Number(it?.qty) || 0,

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -1,8 +1,8 @@
 // src/storage/db.ts
-import type { Item } from './Storage';
-import { PRESETS } from '../presets';
-import { nowISO } from '../utils/time';
-import { updateHistoryItemId, ensureHistoryNames } from './history';
+import type { Item } from './Storage.ts';
+import { PRESETS } from '../presets.ts';
+import { nowISO } from '../utils/time.ts';
+import { updateHistoryItemId, ensureHistoryNames } from './history.ts';
 
 const LS_KEY = 'stocklite/items';
 

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -2,7 +2,7 @@
 import type { Item } from './Storage';
 import { PRESETS } from '../presets';
 import { nowISO } from '../utils/time';
-import { updateHistoryItemId } from './history';
+import { updateHistoryItemId, ensureHistoryNames } from './history';
 
 const LS_KEY = 'stocklite/items';
 
@@ -44,10 +44,9 @@ export const loadAll = (): Item[] => {
   const raw = read();
   const arr = raw.map(normalize);
   raw.forEach((orig, i) => {
-    if (orig.id !== arr[i].id) {
-      updateHistoryItemId(orig.id || '', arr[i].id, orig.name || arr[i].name);
-    }
+    updateHistoryItemId(orig.id || '', arr[i].id, orig.name || arr[i].name);
   });
+  ensureHistoryNames(arr);
   write(arr);
   return arr;
 };

--- a/src/storage/db.ts
+++ b/src/storage/db.ts
@@ -2,6 +2,7 @@
 import type { Item } from './Storage';
 import { PRESETS } from '../presets';
 import { nowISO } from '../utils/time';
+import { updateHistoryItemId } from './history';
 
 const LS_KEY = 'stocklite/items';
 
@@ -40,7 +41,13 @@ const normalize = (it: any): Item => ({
 });
 
 export const loadAll = (): Item[] => {
-  const arr = read().map(normalize);
+  const raw = read();
+  const arr = raw.map(normalize);
+  raw.forEach((orig, i) => {
+    if (orig.id !== arr[i].id) {
+      updateHistoryItemId(orig.id || '', arr[i].id, orig.name || arr[i].name);
+    }
+  });
   write(arr);
   return arr;
 };

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -58,6 +58,21 @@ export const appendHistory = (entry: HistoryEntry) => {
   write(all);
 };
 
+export const ensureHistoryNames = (items: { id: string; name: string }[]) => {
+  const arr = read();
+  let changed = false;
+  for (const e of arr) {
+    if (!e.itemName) {
+      const it = items.find(i => i.id === e.itemId);
+      if (it) {
+        e.itemName = it.name;
+        changed = true;
+      }
+    }
+  }
+  if (changed) write(arr);
+};
+
 export const recentHistory = (limit = 10): HistoryEntry[] => {
   const all = read();
   return all.slice(-limit).reverse();

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -36,6 +36,19 @@ const write = (arr: HistoryEntry[]) => {
   }
 };
 
+export const updateHistoryItemId = (oldId: string, newId: string, name?: string) => {
+  const arr = read();
+  let changed = false;
+  for (const e of arr) {
+    if (e.itemId === oldId || (!e.itemId && name && e.itemName === name)) {
+      e.itemId = newId;
+      if (name) e.itemName = name;
+      changed = true;
+    }
+  }
+  if (changed) write(arr);
+};
+
 export const appendHistory = (entry: HistoryEntry) => {
   const all = read();
   all.push(entry);

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -40,7 +40,10 @@ export const updateHistoryItemId = (oldId: string, newId: string, name?: string)
   const arr = read();
   let changed = false;
   for (const e of arr) {
-    if (e.itemId === oldId || (!e.itemId && name && e.itemName === name)) {
+    if (
+      e.itemId === oldId ||
+      (oldId === '' && !e.itemId && name && e.itemName === name)
+    ) {
       e.itemId = newId;
       if (name) e.itemName = name;
       changed = true;

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -42,7 +42,7 @@ export const updateHistoryItemId = (oldId: string, newId: string, name?: string)
   for (const e of arr) {
     if (
       e.itemId === oldId ||
-      (oldId === '' && !e.itemId && name && e.itemName === name)
+      (!e.itemId && name && e.itemName === name)
     ) {
       e.itemId = newId;
       if (name) e.itemName = name;

--- a/src/storage/history.ts
+++ b/src/storage/history.ts
@@ -1,0 +1,62 @@
+// src/storage/history.ts
+export type HistoryEntry = {
+  timestamp: string; // ISO
+  itemId: string;
+  itemName: string;
+  delta: number;
+  qtyAfter: number;
+  reason: 'inc' | 'dec' | 'edit' | 'add' | 'delete';
+};
+
+const LS_KEY = 'stocklite/history';
+
+const normalize = (e: any): HistoryEntry => ({
+  timestamp: typeof e?.timestamp === 'string' ? e.timestamp : new Date().toISOString(),
+  itemId: typeof e?.itemId === 'string' ? e.itemId : '',
+  itemName: typeof e?.itemName === 'string' ? e.itemName : '',
+  delta: typeof e?.delta === 'number' ? e.delta : Number(e?.delta) || 0,
+  qtyAfter: typeof e?.qtyAfter === 'number' ? e.qtyAfter : Number(e?.qtyAfter) || 0,
+  reason: (e?.reason as HistoryEntry['reason']) || 'edit',
+});
+
+const read = (): HistoryEntry[] => {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const arr = JSON.parse(localStorage.getItem(LS_KEY) || '[]');
+    if (Array.isArray(arr)) return arr.map(normalize);
+  } catch {
+    /* ignore */
+  }
+  return [];
+};
+
+const write = (arr: HistoryEntry[]) => {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(LS_KEY, JSON.stringify(arr));
+  }
+};
+
+export const appendHistory = (entry: HistoryEntry) => {
+  const all = read();
+  all.push(entry);
+  write(all);
+};
+
+export const recentHistory = (limit = 10): HistoryEntry[] => {
+  const all = read();
+  return all.slice(-limit).reverse();
+};
+
+export const historyForItem = (itemId: string, since?: string): HistoryEntry[] => {
+  return read().filter(e => e.itemId === itemId && (!since || e.timestamp >= since));
+};
+
+export const historySince = (iso: string): HistoryEntry[] => {
+  return read().filter(e => e.timestamp >= iso);
+};
+
+export const pruneBefore = (iso: string) => {
+  const arr = read().filter(e => e.timestamp >= iso);
+  write(arr);
+};
+

--- a/src/style.css
+++ b/src/style.css
@@ -201,3 +201,19 @@ select.ed-cat{
 }
 
 .headerbar + .offline{ top: 56px; }
+
+/* ---- 履歴 ---- */
+.hist-chart{ margin:20px auto; max-width:320px; }
+.hist-stats{ text-align:center; font-size:12px; color:var(--muted); margin-top:4px; }
+.hist-list{
+  list-style:none;
+  margin:12px 16px;
+  padding:0;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  font-size:14px;
+}
+.hist-list li{ display:flex; gap:8px; }
+.hist-list .dt{ color:var(--muted); }
+.recent{ margin-top:24px; }

--- a/src/style.css
+++ b/src/style.css
@@ -80,6 +80,7 @@ h2.cat { margin: 18px 12px 8px; font-size: 20px; letter-spacing: .02em; }
 .qty b{ font-size:18px; }
 .actions{ display:flex; gap:8px; }
 .actions .btn{ width:54px; height:48px; font-size:20px; border-radius:12px; }
+.actions .btn.hist{ width:48px; font-size:14px; }
 .row3{ color:var(--muted); margin-top:8px; }
 
 /* ---- 編集画面 ---- */

--- a/src/style.css.d.ts
+++ b/src/style.css.d.ts
@@ -1,0 +1,2 @@
+declare const css: string;
+export default css;

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -1,0 +1,6 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('basic arithmetic', () => {
+  assert.equal(1 + 1, 2);
+});

--- a/tests/history-missing-id.test.js
+++ b/tests/history-missing-id.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import { appendHistory } from '../src/storage/history.ts';
+
+// verify renderHistory links blank itemId entries by name
+
+test('renderHistory links history with blank itemId by name', async () => {
+  const dom = new JSDOM('<!DOCTYPE html><div id="app"></div>', { url: 'https://local.test' });
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.localStorage = dom.window.localStorage;
+
+  // prepare item stored without corresponding history id
+  const item = {
+    id: 'id2',
+    name: 'テスト品',
+    category: '',
+    qty: 2,
+    threshold: 0,
+    lastRefillAt: '',
+    nextRefillAt: '',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    deleted: false,
+    version: 1,
+  };
+  dom.window.localStorage.setItem('stocklite/items', JSON.stringify([item]));
+
+  // history entry with blank itemId but matching name
+  appendHistory({
+    timestamp: '2024-01-02T00:00:00.000Z',
+    itemId: '',
+    itemName: 'テスト品',
+    delta: -1,
+    qtyAfter: 1,
+    reason: 'dec',
+  });
+
+  const { renderHistory } = await import('../src/main.ts');
+  await renderHistory('id2');
+
+  const title = dom.window.document.querySelector('.title')?.textContent;
+  assert.equal(title, 'テスト品の履歴');
+  const canvas = dom.window.document.querySelector('canvas');
+  assert.ok(canvas, 'canvas should exist for graph');
+
+  dom.window.close();
+  delete globalThis.window;
+  delete globalThis.document;
+  delete globalThis.localStorage;
+});

--- a/tests/history-ui.test.js
+++ b/tests/history-ui.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import { appendHistory } from '../src/storage/history.ts';
+
+// test that history view resolves item name and shows graph
+
+test('renderHistory shows item name and graph', async () => {
+  const dom = new JSDOM('<!DOCTYPE html><div id="app"></div>', { url: 'https://local.test' });
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.localStorage = dom.window.localStorage;
+
+  // dynamic import after env setup so main() does not run
+  const { renderHistory } = await import('../src/main.ts');
+
+  // prepare history with known item
+  const iso = new Date().toISOString();
+  appendHistory({
+    timestamp: iso,
+    itemId: 'id1',
+    itemName: 'テスト品',
+    delta: 1,
+    qtyAfter: 1,
+    reason: 'add',
+  });
+
+  await renderHistory('id1');
+
+  const title = dom.window.document.querySelector('.title')?.textContent;
+  assert.equal(title, 'テスト品の履歴');
+  const canvas = dom.window.document.querySelector('canvas');
+  assert.ok(canvas, 'canvas should exist for graph');
+
+  dom.window.close();
+  delete globalThis.window;
+  delete globalThis.document;
+  delete globalThis.localStorage;
+});

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { appendHistory, historyForItem, ensureHistoryNames } from '../src/storage/history.ts';
+
+const createLocalStorage = () => {
+  let store = {};
+  return {
+    getItem: key => (key in store ? store[key] : null),
+    setItem: (key, value) => { store[key] = String(value); },
+    removeItem: key => { delete store[key]; },
+    clear: () => { store = {}; }
+  };
+};
+
+globalThis.localStorage = createLocalStorage();
+
+test('ensureHistoryNames fills missing itemName', () => {
+  localStorage.clear();
+  appendHistory({
+    timestamp: '2024-01-01T00:00:00.000Z',
+    itemId: 'id1',
+    itemName: '',
+    delta: 1,
+    qtyAfter: 1,
+    reason: 'add'
+  });
+
+  ensureHistoryNames([{ id: 'id1', name: 'テスト品' }]);
+  const hist = historyForItem('id1');
+  assert.equal(hist[0].itemName, 'テスト品');
+});


### PR DESCRIPTION
## Summary
- track quantity changes in localStorage history
- show 90-day history chart with stats
- export last year's history as CSV

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c6d0f973d88327ac4db0ba5952d21e