### PR TITLE
Fix PWA safe area padding and edit save flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
     <title>StockLite</title>
 
     <!-- スタイル（style.css のみ） -->

--- a/src/main.ts
+++ b/src/main.ts
@@ -780,10 +780,6 @@ async function renderEdit() {
     btnSaveAll.addEventListener('click', async () => {
       if (btnSaveAll.disabled) return;
 
-      const originalLabel = btnSaveAll.textContent ?? '';
-      btnSaveAll.disabled = true;
-      btnSaveAll.textContent = '保存中…';
-
       const itemMap = new Map(items.map(it => [it.id, it]));
       const rows = Array.from(root.querySelectorAll<HTMLDivElement>('.edit-row[data-item-id]'));
       const updates: { original: Item; updated: Item; changeMeta?: ChangeMeta }[] = [];
@@ -824,12 +820,19 @@ async function renderEdit() {
       }
 
       if (!updates.length) {
-        if (btnSaveAll.isConnected) {
-          btnSaveAll.textContent = originalLabel;
-          btnSaveAll.disabled = false;
-        }
+        location.hash = '';
         return;
       }
+
+      const originalLabel = btnSaveAll.textContent ?? '';
+      const restoreButtonState = () => {
+        if (!btnSaveAll.isConnected) return;
+        btnSaveAll.textContent = originalLabel;
+        btnSaveAll.disabled = false;
+      };
+
+      btnSaveAll.disabled = true;
+      btnSaveAll.textContent = '保存中…';
 
       try {
         for (const { original, updated, changeMeta } of updates) {
@@ -850,14 +853,12 @@ async function renderEdit() {
       } catch (err) {
         console.error(err);
         alert('保存に失敗しました');
-        if (btnSaveAll.isConnected) {
-          btnSaveAll.textContent = originalLabel;
-          btnSaveAll.disabled = false;
-        }
+        restoreButtonState();
         return;
       }
 
-      await renderEdit();
+      restoreButtonState();
+      location.hash = '';
     });
   }
 

--- a/src/style.css
+++ b/src/style.css
@@ -16,7 +16,14 @@ body {
   color: #222;
   background: #f6f7fb;
   overscroll-behavior-y: contain;
-  padding-bottom: env(safe-area-inset-bottom, 0);
+  padding-bottom: 0;
+}
+
+#app::after {
+  content: '';
+  display: block;
+  height: 16px;
+  height: calc(16px + env(safe-area-inset-bottom));
 }
 :root {
   --surface: #fff;
@@ -96,7 +103,10 @@ h2.cat { margin: 18px 12px 8px; font-size: 20px; letter-spacing: .02em; }
 .row3{ color:var(--muted); margin-top:8px; }
 
 /* ---- 編集画面 ---- */
-.edit-panel{ padding: 8px 8px 18px; }
+.edit-panel{
+  padding: 8px 8px 18px;
+  padding: 8px 8px calc(18px + env(safe-area-inset-bottom, 0));
+}
 .edit-list{ display:flex; flex-direction:column; gap:10px; }
 
 .edit-head{
@@ -249,6 +259,8 @@ body.drawer-open{ overflow:hidden; }
   display:flex;
   flex-direction:column;
   max-height: min(90vh, 720px);
+  padding-bottom: 0;
+  padding-bottom: env(safe-area-inset-bottom, 0);
 }
 .drawer-overlay.open .drawer{ transform: translateY(0); }
 


### PR DESCRIPTION
## Summary
- allow the PWA viewport to fill the screen while respecting safe areas
- add bottom spacing via a root-level safe-area spacer so list and edit screens stay clear of the home indicator
- return to the list view after completing the bulk save action in the editor

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9097ef9f48327be204a642e092da4