### PR TITLE
Refine viewport sizing for PWA preview

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -6,7 +6,10 @@
 *,
 *::before,
 *::after { box-sizing: border-box; }
-html, body { height: 100%; }
+html,
+body {
+  min-height: 100%;
+}
 html { -webkit-text-size-adjust: 100%; }
 body {
   margin: 0;
@@ -16,11 +19,17 @@ body {
   color: #222;
   background: #f6f7fb;
   overscroll-behavior-y: contain;
+  min-height: 100vh;
+  min-height: var(--app-viewport);
   padding-bottom: 16px;
   padding-bottom: calc(16px + constant(safe-area-inset-bottom));
   padding-bottom: calc(16px + env(safe-area-inset-bottom));
 }
+#app {
+  min-height: inherit;
+}
 :root {
+  --app-viewport: 100vh;
   --surface: #fff;
   --border: #e6e7ef;
   --muted: #6a6f85;
@@ -28,6 +37,11 @@ body {
   --danger: #de3d3d;
   --ok: #0a8f3c;
   --shadow: 0 2px 10px rgba(16,24,40,.06);
+}
+@supports (height: 100dvh) {
+  :root {
+    --app-viewport: 100dvh;
+  }
 }
 
 /* ---- generic ---- */
@@ -257,6 +271,7 @@ body.drawer-open{ overflow:hidden; }
   display:flex;
   flex-direction:column;
   max-height: min(90vh, 720px);
+  max-height: min(calc(var(--app-viewport) * 0.9), 720px);
   padding-bottom: 0;
   padding-bottom: constant(safe-area-inset-bottom);
   padding-bottom: env(safe-area-inset-bottom);


### PR DESCRIPTION
## Summary
- expand the display-mode detection so preview, minimal-ui, and window-controls-overlay shells also opt into manual viewport sizing
- compute the CSS viewport variable from the largest reliable measurement (innerHeight, clientHeight, visualViewport height plus offsets) and avoid redundant writes while reacting to resize/scroll events

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c932e7a8b48327a7689ba514dd184a